### PR TITLE
Avoid reseting blend operation via flag

### DIFF
--- a/src/client/particles.cpp
+++ b/src/client/particles.cpp
@@ -106,7 +106,6 @@ Particle::Particle(
 			video::EMFN_MODULATE_1X,
 			video::EAS_TEXTURE | video::EAS_VERTEX_COLOR);
 	m_material.BlendOperation = blendop;
-	m_material.setFlag(video::EMF_BLEND_OPERATION, true);
 	m_material.setTexture(0, m_texture.ref);
 	m_texpos = texpos;
 	m_texsize = texsize;


### PR DESCRIPTION
Fixes BlendMode::sub for the particles

This PR requires minetest/irrlicht#112 to be merged to avoid flicker in the HUD after the particles with BlendMode::sub are rendered.

## To do

This PR is Ready for Review.

## How to test

1. Build Irrlicht with minetest/irrlicht#112
2. Redefine `experimental:particle_spawner` as follows:
```
minetest.register_tool("experimental:particle_spawner", {
	description = "Particle Spawner".."\n"..
		"Punch: Spawn random test particle",
	inventory_image = "experimental_tester_tool_1.png^[invert:g",
	groups = { testtool = 1, disable_repair = 1 },
	on_use = function(itemstack, user, pointed_thing)
		local pos = minetest.get_pointed_thing_position(pointed_thing, true)
		if pos == nil then
			if user then
				pos = user:get_pos()
			end
		end
		pos = vector.add(pos, {x=0, y=0.5, z=0})
		local blends = {"add", "sub" }
		local blend = blends[math.ceil(math.random() * #blends)]
		minetest.chat_send_all("blend="..blend)
		local tex, anim
		-- if math.random(0, 1) == 0 then
			tex = "experimental_particle_sheet.png^[opacity:100"
			anim = {type="sheet_2d", frames_w=3, frames_h=2, frame_length=0.01}
		-- else
		-- 	tex = "experimental_particle_vertical.png"
		-- 	anim = {type="vertical_frames", aspect_w=16, aspect_h=16, length=1}
		-- end

		minetest.add_particlespawner({
			pos = {min=pos, max=vector.add(pos, {x=1,y=1,z=1})},
			vel = {min={x=-1, y=1, z=-1},max={x=1,y=1,z=1}},
			acc = {x=0, y=-4, z=0},
			time=2,
			amount=100,
			expirationtime = 6,
			collisiondetection = true,
			bounce = 1,
			texture = { name = tex, blend = blend },
			animation = anim,
			size = 4,
			glow = math.random(0, 5)
		})
	end,
})
```
3. Start the game, get particle spawner and spawn some particles.
4. Observe that the particles are red when the mode is 'add' and green when the mode is 'sub'
