### PR TITLE
Suggested changes to particles

### DIFF
--- a/src/network/clientpackethandler.cpp
+++ b/src/network/clientpackethandler.cpp
@@ -1051,14 +1051,14 @@ void Client::handleCommand_AddParticleSpawner(NetworkPacket* pkt)
 		using ParticleParamTypes::AttractorKind;
 		if (p.attractor_kind != AttractorKind::none) {
 			p.attract.deSerialize(is);
-			p.attractor.deSerialize(is);
+			p.attractor_origin.deSerialize(is);
 			p.attractor_attachment = readU16(is);
 			/* we only check the first bit, in order to allow this value
 			 * to be turned into a bit flag field later if needed */
 			p.attractor_kill = !!(readU8(is) & 1);
 			if (p.attractor_kind != AttractorKind::point) {
-				p.attractor_angle.deSerialize(is);
-				p.attractor_angle_attachment = readU16(is);
+				p.attractor_direction.deSerialize(is);
+				p.attractor_direction_attachment = readU16(is);
 			}
 		}
 		p.radius.deSerialize(is);

--- a/src/particles.h
+++ b/src/particles.h
@@ -415,10 +415,10 @@ struct ParticleSpawnerParameters : CommonParticleParams
 	ParticleParamTypes::AttractorKind
 		attractor_kind;
 	ParticleParamTypes::v3fTween
-		attractor, attractor_angle;
+		attractor_origin, attractor_direction;
 	// object IDs
 	u16 attractor_attachment = 0,
-	    attractor_angle_attachment = 0;
+	    attractor_direction_attachment = 0;
 	// do particles disappear when they cross the attractor threshold?
 	bool attractor_kill = true;
 

--- a/src/script/lua_api/l_particles.cpp
+++ b/src/script/lua_api/l_particles.cpp
@@ -233,11 +233,11 @@ int ModApiParticles::l_add_particlespawner(lua_State *L)
 
 			if (p.attractor_kind != AttractorKind::none) {
 				LuaParticleParams::readTweenTable(L, "strength", p.attract);
-				LuaParticleParams::readTweenTable(L, "origin", p.attractor);
+				LuaParticleParams::readTweenTable(L, "origin", p.attractor_origin);
 				p.attractor_attachment = LuaParticleParams::readAttachmentID(L, "origin_attached");
 				if (p.attractor_kind != AttractorKind::point) {
-					LuaParticleParams::readTweenTable(L, "angle", p.attractor_angle);
-					p.attractor_angle_attachment = LuaParticleParams::readAttachmentID(L, "direction_attached");
+					LuaParticleParams::readTweenTable(L, "direction", p.attractor_direction);
+					p.attractor_direction_attachment = LuaParticleParams::readAttachmentID(L, "direction_attached");
 				}
 			}
 		} else {

--- a/src/script/lua_api/l_particles_local.cpp
+++ b/src/script/lua_api/l_particles_local.cpp
@@ -137,11 +137,11 @@ int ModApiParticlesLocal::l_add_particlespawner(lua_State *L)
 
 		if (p.attractor_kind != AttractorKind::none) {
 			LuaParticleParams::readTweenTable(L, "strength", p.attract);
-			LuaParticleParams::readTweenTable(L, "origin", p.attractor);
+			LuaParticleParams::readTweenTable(L, "origin", p.attractor_origin);
 			p.attractor_attachment = LuaParticleParams::readAttachmentID(L, "origin_attached");
 			if (p.attractor_kind != AttractorKind::point) {
-				LuaParticleParams::readTweenTable(L, "direction", p.attractor_angle);
-				p.attractor_angle_attachment = LuaParticleParams::readAttachmentID(L, "direction_attached");
+				LuaParticleParams::readTweenTable(L, "direction", p.attractor_direction);
+				p.attractor_direction_attachment = LuaParticleParams::readAttachmentID(L, "direction_attached");
 			}
 		}
 	} else {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -1679,12 +1679,12 @@ void Server::SendAddParticleSpawner(session_t peer_id, u16 protocol_version,
 		ParticleParamTypes::serializeParameterValue(os, p.attractor_kind);
 		if (p.attractor_kind != ParticleParamTypes::AttractorKind::none) {
 			p.attract.serialize(os);
-			p.attractor.serialize(os);
+			p.attractor_origin.serialize(os);
 			writeU16(os, p.attractor_attachment); /* object ID */
 			writeU8(os, p.attractor_kill);
 			if (p.attractor_kind != ParticleParamTypes::AttractorKind::point) {
-				p.attractor_angle.serialize(os);
-				writeU16(os, p.attractor_angle_attachment);
+				p.attractor_direction.serialize(os);
+				writeU16(os, p.attractor_direction_attachment);
 			}
 		}
 		p.radius.serialize(os);


### PR DESCRIPTION
* Align internal property names with API names
* Make attractor direction follow attached object rotation

## To do

This PR is a Ready for Review.

## How to test

1. Everything should work as expected
2. Particles of the following spawner should attract to a line which follows rotation of the player (user):

```
		minetest.add_particlespawner({
			pos = {min=vector.add(pos, vector.new(-4, -4, -4)), max=vector.add(pos, vector.new(4,4,4))},
			time=10,
			amount=5000,
			expirationtime = 6,
			collisiondetection = true,
			bounce = 1,
			texture = { name = tex, blend = blend },
			animation = anim,
			size = 4,
			glow = math.random(0, 5),
			attract = {
				kind = "line",
				origin = vector.add(pos, vector.new(0, 0, 0)),
				direction = vector.new(1, 0, 0),
				direction_attached = user,
				strength = 1,
			}
		})
```
